### PR TITLE
Update to pipes-attoparsec 0.5

### DIFF
--- a/pipes-aeson.cabal
+++ b/pipes-aeson.cabal
@@ -34,7 +34,7 @@ library
     , attoparsec       (>=0.10  && <0.12)
     , base             (>=4.5   && <5.0)
     , pipes            (>=4.1   && <4.2)
-    , pipes-attoparsec (>=0.4   && <0.5)
+    , pipes-attoparsec (>=0.5   && <0.6)
     , pipes-bytestring (>=2.0   && <2.1)
     , pipes-parse      (>=3.0.1 && <3.1)
     , bytestring       (>=0.9.2.1)

--- a/src/Pipes/Aeson/Internal.hs
+++ b/src/Pipes/Aeson/Internal.hs
@@ -86,8 +86,9 @@ decodeL
 decodeL parser = do
     ev <- PA.parseL parser
     return (case ev of
-      Left  e      -> Left (AttoparsecError e)
-      Right (n, v) -> case Ae.fromJSON v of
+      Nothing             -> Left (AttoparsecError (PA.ParsingError [] "Failed reading: not enough bytes"))
+      Just (Left  e)      -> Left (AttoparsecError e)
+      Just (Right (n, v)) -> case Ae.fromJSON v of
         Ae.Error e   -> Left (FromJSONError e)
         Ae.Success a -> Right (n, a))
 {-# INLINABLE decodeL #-}


### PR DESCRIPTION
`pipes-attoparsec-0.5` returns `Nothing` when the producer is exhausted. I check for this explicitely and throw the error that the attoparsec `value'` parser would throw in this case. Not sure if this is the right way to fix it, but I couldn't think of a better way  
