### PR TITLE
Update pipes-aeson.cabal

### DIFF
--- a/pipes-aeson.cabal
+++ b/pipes-aeson.cabal
@@ -35,7 +35,7 @@ library
     , base             (>=4.5   && <5.0)
     , pipes            (>=4.1   && <4.2)
     , pipes-attoparsec (>=0.5   && <0.6)
-    , pipes-bytestring (>=2.0   && <2.1)
+    , pipes-bytestring (>=2.0   && <2.2)
     , pipes-parse      (>=3.0.1 && <3.1)
     , bytestring       (>=0.9.2.1)
     , transformers     (>=0.2   && <0.5)


### PR DESCRIPTION
As with `pipes-binary` this just updates the constraint on `pipes-bytestring` to allow 2.1.x
