### PR TITLE
Polish docs and hlint suggestions

### DIFF
--- a/src/Pipes/Aeson.hs
+++ b/src/Pipes/Aeson.hs
@@ -93,12 +93,10 @@ encodeArray = U.encode
 -- 'Ae.FromJSON' instance.
 --
 -- Any of those steps can fail, in which case a 'I.DecodingError' will report
--- the precise error and at which the step it happened.
+-- the precise error and at which step it happened.
 
 
 -- | Decodes an 'Ae.Object' or 'Ae.Array' JSON value from the underlying state.
---
--- Returns either the decoded entitiy, or a 'I.DecodingError' in case of error.
 --
 -- It returns 'Nothing' if the underlying 'Producer' is exhausted, otherwise
 -- it returns either the decoded entity or a 'I.DecodingError' in case of error.
@@ -178,4 +176,4 @@ decodedL f k p0 = fmap _encode (k (I.consecutively decode p0))
 --------------------------------------------------------------------------------
 -- Internal tools --------------------------------------------------------------
 
-type Lens' s a = forall f . Functor f => (a -> f a) -> (s -> f s)
+type Lens' s a = forall f . Functor f => (a -> f a) -> s -> f s

--- a/src/Pipes/Aeson/Internal.hs
+++ b/src/Pipes/Aeson/Internal.hs
@@ -75,8 +75,6 @@ consecutively parser = step where
 -- | Decodes a 'Ae.FromJSON' value from the underlying state using the given
 -- 'Attoparsec.Parser' in order to obtain an 'Ae.Value' first.
 --
--- Returns either the decoded entitiy, or a 'I.DecodingError' in case of error.
---
 -- It returns 'Nothing' if the underlying 'Producer' is exhausted, otherwise
 -- it returns either the decoded entity or a 'I.DecodingError' in case of error.
 decodeL

--- a/src/Pipes/Aeson/Unchecked.hs
+++ b/src/Pipes/Aeson/Unchecked.hs
@@ -43,7 +43,7 @@ encode = PB.fromLazy . Ae.encode
 -- instance, not just 'Ae.Array' or 'Ae.Object'.
 decode
   :: (Monad m, Ae.FromJSON a)
-  => Pipes.Parser B.ByteString m ((Maybe (Either I.DecodingError a))) -- ^
+  => Pipes.Parser B.ByteString m (Maybe (Either I.DecodingError a)) -- ^
 decode = fmap (fmap snd) `liftM` decodeL
 {-# INLINABLE decode #-}
 
@@ -97,4 +97,4 @@ decodedL k p = fmap _encode (k (I.consecutively decodeL p))
 --------------------------------------------------------------------------------
 -- Internal tools --------------------------------------------------------------
 
-type Lens' s a = forall f . Functor f => (a -> f a) -> (s -> f s)
+type Lens' s a = forall f . Functor f => (a -> f a) -> s -> f s


### PR DESCRIPTION
Hi,

I noticed some small documentation issues and used the opportunity to also apply `hlint` suggestions.

Detailed list of changes:
- remove redundant sentence for `Aeson.decode`
- remove superfluous `the`
- apply HLint suggestions in Aeson and Aeson.Internal
- remove redundant sentence for `Aeson.decodeL`

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
