### PR TITLE
Bump aeson upper limit to 0.12

### DIFF
--- a/pipes-aeson.cabal
+++ b/pipes-aeson.cabal
@@ -30,7 +30,7 @@ library
                    Pipes.Aeson.Unchecked
   other-modules:   Pipes.Aeson.Internal
   build-depends:
-      aeson            (>=0.6.1 && <0.11)
+      aeson            (>=0.6.1 && <0.12)
     , attoparsec       (>=0.10  && <0.14)
     , base             (>=4.5   && <5.0)
     , pipes            (>=4.1   && <4.2)


### PR DESCRIPTION
We hit this issue in our project. Would very much appreciate a release.

Thanks so much for this awesome library!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/k0001/pipes-aeson/15)
<!-- Reviewable:end -->
