### PR TITLE
Bump pipes to allow latest

### DIFF
--- a/pipes-aeson.cabal
+++ b/pipes-aeson.cabal
@@ -33,7 +33,7 @@ library
       aeson            (>=0.6.1 && <0.12)
     , attoparsec       (>=0.10  && <0.14)
     , base             (>=4.5   && <5.0)
-    , pipes            (>=4.1   && <4.2)
+    , pipes            (>=4.1   && <4.3)
     , pipes-attoparsec (>=0.5   && <0.6)
     , pipes-bytestring (>=2.0   && <2.2)
     , pipes-parse      (>=3.0.1 && <3.1)


### PR DESCRIPTION
The Hackage pipes is at 4.2.0