### PR TITLE
GHC 9.0 compatibility

### DIFF
--- a/pkg.nix
+++ b/pkg.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, attoparsec, base, bytestring, pipes
-, pipes-attoparsec, pipes-bytestring, pipes-parse, stdenv
+, pipes-attoparsec, pipes-bytestring, pipes-parse, lib
 , transformers
 }:
 mkDerivation {
@@ -12,5 +12,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/k0001/pipes-aeson";
   description = "Encode and decode JSON streams using Aeson and Pipes";
-  license = stdenv.lib.licenses.bsd3;
+  license = lib.licenses.bsd3;
 }

--- a/release.nix
+++ b/release.nix
@@ -14,8 +14,8 @@ hsPackageSetConfig = self: super: {
   pipes-aeson = self.callPackage (import ./pkg.nix) {};
 };
 
-ghc802 = pkgs.haskell.packages.ghc902.override {
+hs = pkgs.haskell.packages.ghc902.override {
   packageSetConfig = hsPackageSetConfig;
 };
 
-in { inherit (ghc802) pipes-aeson; }
+in { inherit (hs) pipes-aeson; }

--- a/release.nix
+++ b/release.nix
@@ -2,8 +2,8 @@
 , nixpkgs ? (import nixpkgsBootstrap {}).fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "b12aacc7c18fb3f29febc842aaa3d0c0e5622546"; # release-17.03
-    sha256 = "1qklmrvfnlk1r6rqxpddllfkv3pihfms370qfsznm959i7hxcv2v"; }
+    rev = "febc24b11ac5369734f81225dc8a200e7dc75319"; # haskell-updates 2022-03-21
+    sha256 = "sha256-JTYxQTU34Xs8tK6fdIWVNOcaAS0p683DknIMq8FnfGg="; }
 }:
 
 let
@@ -14,7 +14,7 @@ hsPackageSetConfig = self: super: {
   pipes-aeson = self.callPackage (import ./pkg.nix) {};
 };
 
-ghc802 = pkgs.haskell.packages.ghc802.override {
+ghc802 = pkgs.haskell.packages.ghc902.override {
   packageSetConfig = hsPackageSetConfig;
 };
 

--- a/src/Pipes/Aeson.hs
+++ b/src/Pipes/Aeson.hs
@@ -61,7 +61,7 @@ import qualified Pipes.Parse           as Pipes
 -- @
 -- 'for' 'cat' 'encodeObject' :: 'Monad' m => 'Pipe' 'Ae.Object' 'B.ByteString' m r
 -- @
-encodeObject :: Monad m => Ae.Object -> Producer' B.ByteString m ()
+encodeObject :: Monad m => Ae.Object -> Proxy x' x () B.ByteString m ()
 encodeObject = U.encode
 {-# INLINABLE encodeObject #-}
 {-# RULES "p >-> for cat encodeObject" forall p .
@@ -76,7 +76,7 @@ encodeObject = U.encode
 -- @
 -- 'for' 'cat' 'encodeArray' :: 'Monad' m => 'Pipe' 'Ae.Array' 'B.ByteString' m r
 -- @
-encodeArray :: Monad m => Ae.Array -> Producer' B.ByteString m ()
+encodeArray :: Monad m => Ae.Array -> Proxy x' x () B.ByteString m ()
 encodeArray = U.encode
 {-# INLINABLE encodeArray #-}
 {-# RULES "p >-> for cat encodeArray" forall p .
@@ -225,7 +225,7 @@ loopL
   -- will never terminate.
   -> Pipes.Producer B.ByteString m r
   -- ^ Raw JSON input.
-  -> Pipes.Producer' (Either I.DecodingError (Int, a)) m r
+  -> Pipes.Proxy x' x () (Either I.DecodingError (Int, a)) m r
 {-# INLINABLE loopL #-}
 loopL = I.loopL Ae.json'
 

--- a/src/Pipes/Aeson/Internal.hs
+++ b/src/Pipes/Aeson/Internal.hs
@@ -112,7 +112,7 @@ loopL
   -- never terminate.
   -> Pipes.Producer B.ByteString m r
   -- ^ Raw JSON input.
-  -> Pipes.Producer' (Either DecodingError (Int, a)) m r
+  -> Pipes.Proxy x' x () (Either DecodingError (Int, a)) m r
 {-# INLINABLE loopL #-}
 loopL parser fp = fix $ \k p0 -> do
    (ye, p1) <- lift (S.runStateT (decodeL parser) p0)

--- a/src/Pipes/Aeson/Unchecked.hs
+++ b/src/Pipes/Aeson/Unchecked.hs
@@ -32,8 +32,9 @@ import qualified Pipes.Parse          as Pipes
 
 -- | Like 'Pipes.Aeson.encode', except it accepts any 'Ae.ToJSON' instance,
 -- not just 'Ae.Array' or 'Ae.Object'.
-encode :: (Monad m, Ae.ToJSON a) => a -> Producer' B.ByteString m ()
-encode = PB.fromLazy . Ae.encode
+-- encode :: (Monad m, Ae.ToJSON a) => a -> Producer' B.ByteString m ()
+encode :: (Monad m, Ae.ToJSON a) => a -> Proxy x' x () PB.ByteString m ()
+encode a = PB.fromLazy (Ae.encode a)
 {-# INLINABLE encode #-}
 {-# RULES "p >-> for cat encode" forall p .
     p >-> for cat encode = for p (\a -> PB.fromLazy (Ae.encode a))
@@ -143,7 +144,7 @@ loopL
   -- will never terminate.
   -> Pipes.Producer B.ByteString m r
   -- ^ Raw JSON input.
-  -> Pipes.Producer' (Either I.DecodingError (Int, a)) m r
+  -> Pipes.Proxy x' x () (Either I.DecodingError (Int, a)) m r
 {-# INLINABLE loopL #-}
 loopL = I.loopL Ae.value'
 


### PR DESCRIPTION
This GHC release regresses a little in completeness, due to "simplified subsumption".

> The main user-facing cost is that some existing programs will require some manual eta-expansion.

https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst#costs-and-drawbacks