### PR TITLE
Relax lower bound on attoparsec-aeson

### DIFF
--- a/pipes-aeson/pipes-aeson.cabal
+++ b/pipes-aeson/pipes-aeson.cabal
@@ -32,7 +32,7 @@ library
   build-depends:
       aeson            (>=0.6.1)
     , attoparsec       (>=0.10)
-    , attoparsec-aeson (>=2.2)
+    , attoparsec-aeson (>=2.1 && <2.3)
     , base             (>=4.5 && <5.0)
     , pipes            (>=4.1)
     , pipes-attoparsec (>=0.5)


### PR DESCRIPTION
`2.1` was added to hackage *after* the initial `2.2` release was done to avoid breakage: https://hackage.haskell.org/package/attoparsec-aeson-2.1.0.0